### PR TITLE
improving serialization of calendar activities for enddatetime

### DIFF
--- a/apis/serializers/farm_activities.py
+++ b/apis/serializers/farm_activities.py
@@ -58,9 +58,9 @@ def quantity_value_serializer_factory(unit_field, value_field):
 class FarmCalendarActivitySerializer(serializers.ModelSerializer):
     activityType = URNRelatedField(class_names=['FarmCalendarActivityType'], source='activity_type', queryset=FarmCalendarActivityType.objects.all())
     hasStartDatetime = serializers.DateTimeField(source='start_datetime')
-    hasEndDatetime = serializers.DateTimeField(source='end_datetime', allow_null=True)
+    hasEndDatetime = serializers.DateTimeField(source='end_datetime', allow_null=True, required=False)
 
-    responsibleAgent = serializers.CharField(source='responsible_agent', allow_null=True)
+    responsibleAgent = serializers.CharField(source='responsible_agent', allow_null=True, required=False)
 
     usesAgriculturalMachinery = URNRelatedField(class_names=['AgriculturalMachine'], source='agricultural_machinery', many=True, queryset=AgriculturalMachine.objects.all())
 

--- a/schema.yml
+++ b/schema.yml
@@ -5595,10 +5595,8 @@ components:
       required:
       - activityType
       - hasCompostMaterial
-      - hasEndDatetime
       - hasStartDatetime
       - id
-      - responsibleAgent
       - usesAgriculturalMachinery
     AddressField:
       type: object
@@ -5737,13 +5735,11 @@ components:
           readOnly: true
       required:
       - activityType
-      - hasEndDatetime
       - hasMeasurement
       - hasNestedOperation
       - hasStartDatetime
       - id
       - isOperatedOn
-      - responsibleAgent
       - usesAgriculturalMachinery
     CompostTurningOperation:
       type: object
@@ -5778,10 +5774,8 @@ components:
             format: uuid
       required:
       - activityType
-      - hasEndDatetime
       - hasStartDatetime
       - id
-      - responsibleAgent
       - usesAgriculturalMachinery
     ContactPersonField:
       type: object
@@ -5830,7 +5824,6 @@ components:
       required:
       - activityType
       - hasAgriCrop
-      - hasEndDatetime
       - hasResult
       - id
       - observedProperty
@@ -5878,11 +5871,9 @@ components:
       required:
       - activityType
       - hasAppliedAmount
-      - hasEndDatetime
       - hasStartDatetime
       - id
       - operatedOn
-      - responsibleAgent
       - usesAgriculturalMachinery
       - usesPesticide
     CropSpeciesSerializerField:
@@ -5932,7 +5923,6 @@ components:
       required:
       - activityType
       - hasAgriCrop
-      - hasEndDatetime
       - hasResult
       - id
       - observedProperty
@@ -6094,10 +6084,8 @@ components:
             format: uuid
       required:
       - activityType
-      - hasEndDatetime
       - hasStartDatetime
       - id
-      - responsibleAgent
       - usesAgriculturalMachinery
     FarmCalendarActivityType:
       type: object
@@ -6325,11 +6313,9 @@ components:
       - activityType
       - hasApplicationMethod
       - hasAppliedAmount
-      - hasEndDatetime
       - hasStartDatetime
       - id
       - operatedOn
-      - responsibleAgent
       - usesAgriculturalMachinery
       - usesFertilizer
     Fertilizer:
@@ -6483,11 +6469,9 @@ components:
       required:
       - activityType
       - hasAppliedAmount
-      - hasEndDatetime
       - hasStartDatetime
       - id
       - operatedOn
-      - responsibleAgent
       - usesAgriculturalMachinery
       - usesIrrigationSystem
     LocationSerializerField:
@@ -6545,7 +6529,6 @@ components:
           type: string
       required:
       - activityType
-      - hasEndDatetime
       - hasResult
       - id
       - observedProperty


### PR DESCRIPTION
Field was already as allow_null, so now it is also no longer required (instead of having the user send a request with a null value).

fix #93


This should fix the error we observed in the weather service for one of the sips (sip 1 or 2) when we did the last deploy fest.