### PR TITLE
enforncing a nested activity form with correct field exclusion

### DIFF
--- a/farm_activities/forms/base.py
+++ b/farm_activities/forms/base.py
@@ -69,11 +69,15 @@ class NestedActivityForm(FarmCalendarActivityForm):
     )
 
     class Meta(FarmCalendarActivityForm.Meta):
-        pass
+        _parent_exc = FarmCalendarActivityForm.Meta.exclude.copy()
+        if 'parent_activity' in _parent_exc:
+            _parent_exc.remove('parent_activity')
+        exclude = _parent_exc
 
 class ObservationForm(NestedActivityForm):
     class Meta(NestedActivityForm.Meta):
         model = Observation
         _parent_exc = NestedActivityForm.Meta.exclude.copy()
-        _parent_exc.remove('parent_activity')
+        if 'parent_activity' in _parent_exc:
+            _parent_exc.remove('parent_activity')
         exclude = _parent_exc


### PR DESCRIPTION
Just saw this issue (#95) when trying to add a irrigation operation to a compost operation. 
The issue happens because only inherithing the base class with general field exclusion for the activity forms was giving inconsistent behavious in the child form classes. To avoid this we need to ensure that the child form classes don't have any required field in the field exclusion variable (`exclude`) in the meta class.

I saw this inconsistency in the behaviour of the irrigation operation (as a nested activty of a compost operation), which doesn't work. Mean while the same form works for the AddRawMaterialOperation as a nested operation for compost operation. With this fix, both cases works correctly.
fix #95 