### PR TITLE
Add: migration command for local admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ docker-compose down
 ## Local Admin User (No Gatekeeper)
 If you are not using the OpenAgri Gatekeeper service to provide authentication and user management, then you should remove the `GATEKEEPER_LOGIN_URL` configuration from your `.env` file. This will make your Farm Calendar service work with its own internal user authentication (using Django's auth and password process).
 
-In this case, you need to first create/migrate database entities:
+In this case, you need to first run the following for initial setup:
 ```
-$ docker compose run --rm web python3 manage.py migrate
+$ docker compose run --rm web python3 manage.py initial_setup
 ```
 
 And then you can create your admin user by running:


### PR DESCRIPTION
When I am following the README, I discovered there is an additional step one needs to run to migrate some database entities. My change just added that command in the README.